### PR TITLE
Return proper 404 if school is not found

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from sqlalchemy.orm import Session
 
@@ -7,12 +7,15 @@ from .filters import SchoolFilter
 from .schemas import School
 
 
-def get_school(db: Session, school_id: str) -> School:
+def get_school(db: Session, school_id: str) -> Optional[School]:
     school = db \
         .query(models.School) \
         .filter(models.School.id == school_id) \
         .first()
-    return School.from_db(school)
+    if school:
+        return School.from_db(school)
+    return None
+
 
 
 def get_schools(db: Session, skip: int = 0, limit: int = 100, filter_params=None) -> List[School]:

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -329,3 +329,14 @@ class TestStates:
         # Assert
         assert response.status_code == 200
         assert len(response.json()) == 2
+
+    def test_get_single_no_result(self, client, db):
+        # Arrange
+        self.__setup_schools(db)
+
+        # Act
+        response = client.get("/schools/NI-12345")
+
+        # Assert
+        assert response.status_code == 404
+


### PR DESCRIPTION
Currently, if a School is not found, `None` is returned
and the `from_db` call would fail leading to a 500.
By exiting early in `crud.py` we can prevent this and return a proper
404.