### PR TITLE
Allow schools without address in schema

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -32,7 +32,7 @@ class State(Enum):
 class School(BaseModel):
     id: str
     name: str
-    address: str
+    address: Optional[str] = None
     address2: Optional[str] = None
     city: Optional[str] = None
     director: Optional[str] = None


### PR DESCRIPTION
The `Grundschule Abtsdorf "Ferdinand Freiligrath"` (ST-ARC00839) and ~800 more schools from Sachsen-Anhalt don't have an address field stored in the database. Our parser refuses to load them. We cannot control this though so we'll adapt the schema instead.